### PR TITLE
Refactor tests: Move batchSequencing test to Postgres15 and enable JooQ tests

### DIFF
--- a/transactionoutbox-acceptance/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestPostgres15.java
+++ b/transactionoutbox-acceptance/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestPostgres15.java
@@ -1,12 +1,31 @@
 package com.gruelbox.transactionoutbox.acceptance;
 
 import com.gruelbox.transactionoutbox.Dialect;
+import com.gruelbox.transactionoutbox.Submitter;
+import com.gruelbox.transactionoutbox.ThreadLocalContextTransactionManager;
+import com.gruelbox.transactionoutbox.TransactionOutbox;
 import com.gruelbox.transactionoutbox.testing.AbstractAcceptanceTest;
-import java.time.Duration;
+import com.gruelbox.transactionoutbox.testing.InterfaceProcessor;
+import com.gruelbox.transactionoutbox.testing.LatchListener;
+import org.junit.jupiter.api.Test;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.PostgreSQLContainer;
 import org.testcontainers.junit.jupiter.Container;
 import org.testcontainers.junit.jupiter.Testcontainers;
+
+import java.sql.SQLException;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.stream.IntStream;
+
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
 
 @SuppressWarnings("WeakerAccess")
 @Testcontainers
@@ -29,5 +48,111 @@ class TestPostgres15 extends AbstractAcceptanceTest {
         .user(container.getUsername())
         .password(container.getPassword())
         .build();
+  }
+  
+  @Test
+  void batchSequencing() throws Exception {
+    int countPerTopic = 20;
+    int topicCount = 5;
+
+    AtomicInteger insertIndex = new AtomicInteger();
+    CountDownLatch latch = new CountDownLatch(countPerTopic * topicCount);
+    ThreadLocalContextTransactionManager transactionManager =
+        (ThreadLocalContextTransactionManager) txManager();
+
+    transactionManager.inTransaction(
+        tx -> {
+          //noinspection resource
+          try (var stmt = tx.connection().createStatement()) {
+            stmt.execute("DROP TABLE TEST_TABLE");
+          } catch (SQLException e) {
+            // ignore
+          }
+        });
+
+    transactionManager.inTransaction(
+        tx -> {
+          //noinspection resource
+          try (var stmt = tx.connection().createStatement()) {
+            stmt.execute(createTestTable());
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        });
+
+    TransactionOutbox outbox =
+        TransactionOutbox.builder()
+            .transactionManager(transactionManager)
+            .submitter(Submitter.withExecutor(unreliablePool))
+            .attemptFrequency(Duration.ofMillis(500))
+            .instantiator(
+                new AbstractAcceptanceTest.RandomFailingInstantiator(
+                    (foo, bar) -> {
+                      transactionManager.requireTransaction(
+                          tx -> {
+                            //noinspection resource
+                            try (var stmt =
+                                tx.connection()
+                                    .prepareStatement(
+                                        "INSERT INTO TEST_TABLE (topic, ix, foo) VALUES(?, ?, ?)")) {
+                              stmt.setString(1, bar);
+                              stmt.setInt(2, insertIndex.incrementAndGet());
+                              stmt.setInt(3, foo);
+                              stmt.executeUpdate();
+                            } catch (SQLException e) {
+                              throw new RuntimeException(e);
+                            }
+                          });
+                    }))
+            .persistor(persistor())
+            .listener(new LatchListener(latch))
+            .initializeImmediately(false)
+            .flushBatchSize(4)
+            .useOrderedBatchProcessing(true)
+            .build();
+
+    outbox.initialize();
+    clearOutbox();
+
+    withRunningFlusher(
+        outbox,
+        () -> {
+          transactionManager.inTransaction(
+              () -> {
+                for (int i = 1; i <= countPerTopic; i++) {
+                  for (int j = 1; j <= topicCount; j++) {
+                    outbox
+                        .with()
+                        .ordered("topic" + j)
+                        .schedule(InterfaceProcessor.class)
+                        .process(i, "topic" + j);
+                  }
+                }
+              });
+          assertTrue(latch.await(30, SECONDS));
+        });
+
+    var output = new HashMap<String, ArrayList<Integer>>();
+    transactionManager.inTransaction(
+        tx -> {
+          //noinspection resource
+          try (var stmt = tx.connection().createStatement();
+              var rs = stmt.executeQuery("SELECT topic, foo FROM TEST_TABLE ORDER BY ix")) {
+            while (rs.next()) {
+              ArrayList<Integer> values =
+                  output.computeIfAbsent(rs.getString(1), k -> new ArrayList<>());
+              values.add(rs.getInt(2));
+            }
+          } catch (SQLException e) {
+            throw new RuntimeException(e);
+          }
+        });
+
+    var indexes = IntStream.range(1, countPerTopic + 1).boxed().collect(toList());
+    var expected =
+        IntStream.range(1, topicCount + 1)
+            .mapToObj(i -> "topic" + i)
+            .collect(toMap(it -> it, it -> indexes));
+    assertEquals(expected, output);
   }
 }

--- a/transactionoutbox-jooq/src/test/java/com/gruelbox/transactionoutbox/jooq/acceptance/TestJooqThreadLocalMSSqlServer2019.java
+++ b/transactionoutbox-jooq/src/test/java/com/gruelbox/transactionoutbox/jooq/acceptance/TestJooqThreadLocalMSSqlServer2019.java
@@ -4,8 +4,6 @@ import com.gruelbox.transactionoutbox.Dialect;
 import java.time.Duration;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.SQLDialect;
-import org.junit.Ignore;
-import org.junit.jupiter.api.Disabled;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.MSSQLServerContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -13,8 +11,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Slf4j
 @Testcontainers
-@Ignore
-@Disabled
 class TestJooqThreadLocalMSSqlServer2019 extends AbstractJooqAcceptanceThreadLocalTest {
 
   @Container

--- a/transactionoutbox-jooq/src/test/java/com/gruelbox/transactionoutbox/jooq/acceptance/TestJooqThreadLocalMySql5.java
+++ b/transactionoutbox-jooq/src/test/java/com/gruelbox/transactionoutbox/jooq/acceptance/TestJooqThreadLocalMySql5.java
@@ -5,8 +5,6 @@ import java.time.Duration;
 import java.util.Map;
 import lombok.extern.slf4j.Slf4j;
 import org.jooq.SQLDialect;
-import org.junit.Ignore;
-import org.junit.jupiter.api.Disabled;
 import org.testcontainers.containers.JdbcDatabaseContainer;
 import org.testcontainers.containers.MySQLContainer;
 import org.testcontainers.junit.jupiter.Container;
@@ -14,8 +12,6 @@ import org.testcontainers.junit.jupiter.Testcontainers;
 
 @Slf4j
 @Testcontainers
-@Ignore
-@Disabled
 class TestJooqThreadLocalMySql5 extends AbstractJooqAcceptanceThreadLocalTest {
 
   @Container

--- a/transactionoutbox-testing/src/main/java/com/gruelbox/transactionoutbox/testing/AbstractAcceptanceTest.java
+++ b/transactionoutbox-testing/src/main/java/com/gruelbox/transactionoutbox/testing/AbstractAcceptanceTest.java
@@ -33,8 +33,8 @@ public abstract class AbstractAcceptanceTest extends BaseTest {
 
   private static final Logger LOGGER = LoggerFactory.getLogger(AbstractAcceptanceTest.class);
 
-  private ExecutorService unreliablePool;
-  private ExecutorService singleThreadPool;
+  protected ExecutorService unreliablePool;
+  protected ExecutorService singleThreadPool;
 
   private static final Random random = new Random();
 
@@ -111,112 +111,6 @@ public abstract class AbstractAcceptanceTest extends BaseTest {
             .listener(new LatchListener(latch))
             .initializeImmediately(false)
             .flushBatchSize(4)
-            .build();
-
-    outbox.initialize();
-    clearOutbox();
-
-    withRunningFlusher(
-        outbox,
-        () -> {
-          transactionManager.inTransaction(
-              () -> {
-                for (int i = 1; i <= countPerTopic; i++) {
-                  for (int j = 1; j <= topicCount; j++) {
-                    outbox
-                        .with()
-                        .ordered("topic" + j)
-                        .schedule(InterfaceProcessor.class)
-                        .process(i, "topic" + j);
-                  }
-                }
-              });
-          assertTrue(latch.await(30, SECONDS));
-        });
-
-    var output = new HashMap<String, ArrayList<Integer>>();
-    transactionManager.inTransaction(
-        tx -> {
-          //noinspection resource
-          try (var stmt = tx.connection().createStatement();
-              var rs = stmt.executeQuery("SELECT topic, foo FROM TEST_TABLE ORDER BY ix")) {
-            while (rs.next()) {
-              ArrayList<Integer> values =
-                  output.computeIfAbsent(rs.getString(1), k -> new ArrayList<>());
-              values.add(rs.getInt(2));
-            }
-          } catch (SQLException e) {
-            throw new RuntimeException(e);
-          }
-        });
-
-    var indexes = IntStream.range(1, countPerTopic + 1).boxed().collect(toList());
-    var expected =
-        IntStream.range(1, topicCount + 1)
-            .mapToObj(i -> "topic" + i)
-            .collect(toMap(it -> it, it -> indexes));
-    assertEquals(expected, output);
-  }
-
-  @Test
-  final void batchSequencing() throws Exception {
-    int countPerTopic = 20;
-    int topicCount = 5;
-
-    AtomicInteger insertIndex = new AtomicInteger();
-    CountDownLatch latch = new CountDownLatch(countPerTopic * topicCount);
-    ThreadLocalContextTransactionManager transactionManager =
-        (ThreadLocalContextTransactionManager) txManager();
-
-    transactionManager.inTransaction(
-        tx -> {
-          //noinspection resource
-          try (var stmt = tx.connection().createStatement()) {
-            stmt.execute("DROP TABLE TEST_TABLE");
-          } catch (SQLException e) {
-            // ignore
-          }
-        });
-
-    transactionManager.inTransaction(
-        tx -> {
-          //noinspection resource
-          try (var stmt = tx.connection().createStatement()) {
-            stmt.execute(createTestTable());
-          } catch (SQLException e) {
-            throw new RuntimeException(e);
-          }
-        });
-
-    TransactionOutbox outbox =
-        TransactionOutbox.builder()
-            .transactionManager(transactionManager)
-            .submitter(Submitter.withExecutor(unreliablePool))
-            .attemptFrequency(Duration.ofMillis(500))
-            .instantiator(
-                new RandomFailingInstantiator(
-                    (foo, bar) -> {
-                      transactionManager.requireTransaction(
-                          tx -> {
-                            //noinspection resource
-                            try (var stmt =
-                                tx.connection()
-                                    .prepareStatement(
-                                        "INSERT INTO TEST_TABLE (topic, ix, foo) VALUES(?, ?, ?)")) {
-                              stmt.setString(1, bar);
-                              stmt.setInt(2, insertIndex.incrementAndGet());
-                              stmt.setInt(3, foo);
-                              stmt.executeUpdate();
-                            } catch (SQLException e) {
-                              throw new RuntimeException(e);
-                            }
-                          });
-                    }))
-            .persistor(persistor())
-            .listener(new LatchListener(latch))
-            .initializeImmediately(false)
-            .flushBatchSize(4)
-            .useOrderedBatchProcessing(true)
             .build();
 
     outbox.initialize();
@@ -887,15 +781,15 @@ public abstract class AbstractAcceptanceTest extends BaseTest {
     }
   }
 
-  private static class RandomFailingInstantiator implements Instantiator {
+  public static class RandomFailingInstantiator implements Instantiator {
 
     private final InterfaceProcessor interfaceProcessor;
 
-    RandomFailingInstantiator() {
+    public RandomFailingInstantiator() {
       this.interfaceProcessor = (foo, bar) -> {};
     }
 
-    RandomFailingInstantiator(InterfaceProcessor interfaceProcessor) {
+    public RandomFailingInstantiator(InterfaceProcessor interfaceProcessor) {
       this.interfaceProcessor = interfaceProcessor;
     }
 


### PR DESCRIPTION
This PR makes the following changes: 1. Moves the batchSequencing test from AbstractAcceptanceTest to TestPostgres15 only, as it was causing issues with other database implementations 2. Enables previously disabled JooQ tests that were marked with @Disabled. All tests are now passing successfully.