### PR TITLE
Add monitoring features for transaction outbox

### DIFF
--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,7 +1,6 @@
 name: PR workflow
 on:
   pull_request:
-    types: [opened, reopened, synchronize]
     branches: [ master ]
 
 jobs:

--- a/.github/workflows/pull_request.yaml
+++ b/.github/workflows/pull_request.yaml
@@ -1,7 +1,7 @@
 name: PR workflow
 on:
   pull_request:
-    types: [opened, reopened]
+    types: [opened, reopened, synchronize]
     branches: [ master ]
 
 jobs:

--- a/README.md
+++ b/README.md
@@ -24,6 +24,9 @@ A flexible implementation of the [Transaction Outbox Pattern](https://microservi
    1. [jOOQ](#jooq)
 1. [Set up the background worker](#set-up-the-background-worker)
 1. [Managing the "dead letter queue"](#managing-the-dead-letter-queue)
+1. [Monitoring and Observability](#monitoring-and-observability)
+   1. [Accessing Retry Count in Listener Callbacks](#accessing-retry-count-in-listener-callbacks)
+   1. [Monitoring Oldest Pending Event Age](#monitoring-oldest-pending-event-age)
 1. [Advanced](#advanced)
    1. [Topics and FIFO ordering](#topics-and-fifo-ordering)
    1. [The nested outbox pattern](#the-nested-outbox-pattern)
@@ -304,6 +307,155 @@ transactionOutboxEntry.unblock(entryId, context);
 ```
 
 A good approach here is to use the [`TransactionOutboxListener`](https://www.javadoc.io/doc/com.gruelbox/transactionoutbox-core/latest/com/gruelbox/transactionoutbox/TransactionOutboxListener.html) callback to post an [interactive Slack message](https://api.slack.com/legacy/interactive-messages) - this can operate as both the alert and the "button" allowing a support engineer to submit the work for reprocessing.
+
+## Monitoring and Observability
+
+Transaction Outbox provides several ways to monitor the health and performance of your outbox processing:
+
+### Accessing Retry Count in Listener Callbacks
+
+All listener callbacks receive the full `TransactionOutboxEntry` object, which includes the retry count via `entry.getAttempts()`. This allows you to create custom metrics and alerts based on retry behavior:
+
+```java
+TransactionOutbox.builder()
+    ...
+    .listener(new TransactionOutboxListener() {
+        @Override
+        public void failure(TransactionOutboxEntry entry, Throwable cause) {
+            int retryCount = entry.getAttempts();
+            
+            // Log with structured data
+            logger.warn("Task failed on attempt {}: {}", retryCount, entry.description(), cause);
+            
+            // Send metrics to DataDog/Prometheus
+            metrics.increment("outbox.task.failure", 
+                "retry_count:" + retryCount,
+                "task_type:" + entry.getInvocation().getClassName());
+            
+            // Alert if retry count is high
+            if (retryCount >= 3) {
+                alerting.warning("Task failing repeatedly: " + entry.description());
+            }
+        }
+        
+        @Override
+        public void scheduled(TransactionOutboxEntry entry) {
+            // Track when tasks are scheduled
+            metrics.increment("outbox.task.scheduled");
+        }
+        
+        @Override
+        public void success(TransactionOutboxEntry entry) {
+            int attempts = entry.getAttempts();
+            // Track success rate and attempts until success
+            metrics.histogram("outbox.task.attempts_until_success", attempts);
+        }
+    })
+    .build();
+```
+
+### Monitoring Oldest Pending Event Age
+
+To monitor for stuck or delayed events, you can query the age of the oldest pending event. This is particularly useful for setting up alerts to detect when the outbox processing is falling behind:
+
+```java
+// In a scheduled monitoring task or health check endpoint
+long ageSeconds = outbox.getOldestPendingEventAgeSeconds();
+
+// Expose as a gauge metric for DataDog
+metrics.gauge("outbox.oldest_pending_event.age_seconds", ageSeconds);
+
+// Expose as a gauge for Prometheus
+Gauge.build()
+    .name("outbox_oldest_pending_event_age_seconds")
+    .help("Age in seconds of the oldest pending event")
+    .register()
+    .set(ageSeconds);
+
+// Alert if age exceeds threshold (e.g., 120 seconds for production incident)
+if (ageSeconds > 120) {
+    alerting.triggerIncident(
+        "Outbox events stuck",
+        "Oldest pending event is " + ageSeconds + " seconds old"
+    );
+}
+```
+
+#### Spring Boot Actuator Health Check Example
+
+```java
+@Component
+public class TransactionOutboxHealthIndicator implements HealthIndicator {
+    
+    private final TransactionOutbox outbox;
+    private final long warningThresholdSeconds = 60;
+    private final long criticalThresholdSeconds = 120;
+    
+    @Override
+    public Health health() {
+        try {
+            long ageSeconds = outbox.getOldestPendingEventAgeSeconds();
+            
+            if (ageSeconds >= criticalThresholdSeconds) {
+                return Health.down()
+                    .withDetail("oldest_pending_event_age_seconds", ageSeconds)
+                    .withDetail("status", "CRITICAL - Events stuck for over 2 minutes")
+                    .build();
+            }
+            
+            if (ageSeconds >= warningThresholdSeconds) {
+                return Health.status("WARNING")
+                    .withDetail("oldest_pending_event_age_seconds", ageSeconds)
+                    .withDetail("status", "WARNING - Events delayed")
+                    .build();
+            }
+            
+            return Health.up()
+                .withDetail("oldest_pending_event_age_seconds", ageSeconds)
+                .withDetail("status", "OK")
+                .build();
+        } catch (Exception e) {
+            return Health.down()
+                .withException(e)
+                .build();
+        }
+    }
+}
+```
+
+#### Micrometer Metrics Example
+
+```java
+@Configuration
+public class TransactionOutboxMetrics {
+    
+    @Bean
+    public MeterBinder outboxMetrics(TransactionOutbox outbox, MeterRegistry registry) {
+        return r -> {
+            // Register a gauge that queries the age on every scrape
+            Gauge.builder("outbox.oldest_pending_event.age.seconds", outbox,
+                    TransactionOutbox::getOldestPendingEventAgeSeconds)
+                .description("Age in seconds of the oldest pending event in the outbox")
+                .register(registry);
+        };
+    }
+}
+```
+
+### Recommended Monitoring Strategy
+
+1. **Track retry counts** in listener callbacks to understand retry patterns and identify problematic tasks
+2. **Monitor oldest pending event age** to detect processing delays or stuck events
+3. **Set up alerts**:
+   - Warning: Oldest pending event > 60 seconds
+   - Critical/Incident: Oldest pending event > 120 seconds
+4. **Dashboard metrics**:
+   - Tasks scheduled per minute
+   - Tasks succeeded per minute
+   - Tasks failed per minute
+   - Tasks blocked (dead letter queue size)
+   - Oldest pending event age
+   - Distribution of retry counts before success
 
 ## Advanced
 

--- a/transactionoutbox-acceptance/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestH2.java
+++ b/transactionoutbox-acceptance/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestH2.java
@@ -10,10 +10,13 @@ import com.gruelbox.transactionoutbox.testing.InterfaceProcessor;
 import com.gruelbox.transactionoutbox.testing.LatchListener;
 import com.gruelbox.transactionoutbox.testing.OrderedEntryListener;
 import java.lang.reflect.InvocationTargetException;
+import java.time.Clock;
 import java.time.Duration;
 import java.time.Instant;
+import java.time.ZoneOffset;
 import java.util.concurrent.CountDownLatch;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import org.junit.jupiter.api.Test;
 import org.slf4j.MDC;
 
@@ -190,8 +193,7 @@ class TestH2 extends AbstractAcceptanceTest {
     TransactionManager transactionManager = txManager();
     
     Instant start = Instant.now();
-    java.util.concurrent.atomic.AtomicReference<Instant> currentTime = 
-        new java.util.concurrent.atomic.AtomicReference<>(start);
+    AtomicReference<Instant> currentTime = new AtomicReference<>(start);
     
     TransactionOutbox outbox =
         TransactionOutbox.builder()
@@ -200,7 +202,7 @@ class TestH2 extends AbstractAcceptanceTest {
             .persistor(Persistor.forDialect(connectionDetails().dialect()))
             .attemptFrequency(Duration.ofMillis(500))
             .submitter(Submitter.withExecutor(r -> {})) // Don't submit - keep it pending
-            .clockProvider(() -> java.time.Clock.fixed(currentTime.get(), java.time.ZoneOffset.UTC))
+            .clockProvider(() -> Clock.fixed(currentTime.get(), ZoneOffset.UTC))
             .initializeImmediately(false)
             .build();
 

--- a/transactionoutbox-acceptance/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestH2.java
+++ b/transactionoutbox-acceptance/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestH2.java
@@ -1,5 +1,6 @@
 package com.gruelbox.transactionoutbox.acceptance;
 
+import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertFalse;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
@@ -167,5 +168,59 @@ class TestH2 extends AbstractAcceptanceTest {
     transactionManager.inTransaction(
         () -> outbox.schedule(InterfaceProcessor.class).process(1, "bar"));
     assertTrue(latch.await(5, TimeUnit.SECONDS));
+  }
+
+  @Test
+  final void getOldestPendingEventAgeSeconds_noPendingEvents() {
+    TransactionManager transactionManager = txManager();
+    TransactionOutbox outbox =
+        TransactionOutbox.builder()
+            .transactionManager(transactionManager)
+            .persistor(Persistor.forDialect(connectionDetails().dialect()))
+            .build();
+
+    outbox.initialize();
+    clearOutbox();
+
+    assertEquals(0L, outbox.getOldestPendingEventAgeSeconds());
+  }
+
+  @Test
+  final void getOldestPendingEventAgeSeconds_withPendingEvents() throws Exception {
+    TransactionManager transactionManager = txManager();
+    TransactionOutbox outbox =
+        TransactionOutbox.builder()
+            .transactionManager(transactionManager)
+            .instantiator(Instantiator.using(clazz -> (InterfaceProcessor) (foo, bar) -> {}))
+            .persistor(Persistor.forDialect(connectionDetails().dialect()))
+            .attemptFrequency(Duration.ofMillis(500))
+            .submitter(Submitter.withExecutor(r -> {})) // Don't submit - keep it pending
+            .initializeImmediately(false)
+            .build();
+
+    outbox.initialize();
+    clearOutbox();
+
+    // Schedule an event but prevent it from being processed
+    transactionManager.inTransaction(
+        () -> outbox.schedule(InterfaceProcessor.class).process(1, "bar"));
+
+    Thread.sleep(2000);
+
+    long age = outbox.getOldestPendingEventAgeSeconds();
+    assertTrue(age >= 2, "Age should be at least 2 seconds, but was: " + age);
+    assertTrue(age < 10, "Age should be less than 10 seconds, but was: " + age);
+
+    // Clean up - flush to process the event with a real executor
+    TransactionOutbox cleanupOutbox =
+        TransactionOutbox.builder()
+            .transactionManager(transactionManager)
+            .instantiator(Instantiator.using(clazz -> (InterfaceProcessor) (foo, bar) -> {}))
+            .persistor(Persistor.forDialect(connectionDetails().dialect()))
+            .build();
+    cleanupOutbox.flush();
+
+    long ageAfterProcessing = outbox.getOldestPendingEventAgeSeconds();
+    assertEquals(0L, ageAfterProcessing, "No pending events after processing");
   }
 }

--- a/transactionoutbox-acceptance/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestH2.java
+++ b/transactionoutbox-acceptance/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestH2.java
@@ -211,17 +211,10 @@ class TestH2 extends AbstractAcceptanceTest {
     assertTrue(age >= 2, "Age should be at least 2 seconds, but was: " + age);
     assertTrue(age < 10, "Age should be less than 10 seconds, but was: " + age);
 
-    // Clean up - create a new outbox with active submitter and flush pending events
-    TransactionOutbox cleanupOutbox =
-        TransactionOutbox.builder()
-            .transactionManager(transactionManager)
-            .instantiator(Instantiator.using(clazz -> (InterfaceProcessor) (foo, bar) -> {}))
-            .persistor(Persistor.forDialect(connectionDetails().dialect()))
-            .build();
-    
-    cleanupOutbox.flush();
+    // Clean up by clearing the outbox
+    clearOutbox();
     
     // Verify no pending events remain
-    assertEquals(0L, outbox.getOldestPendingEventAgeSeconds(), "No pending events after processing");
+    assertEquals(0L, outbox.getOldestPendingEventAgeSeconds(), "No pending events after cleanup");
   }
 }

--- a/transactionoutbox-acceptance/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestH2.java
+++ b/transactionoutbox-acceptance/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestH2.java
@@ -188,6 +188,11 @@ class TestH2 extends AbstractAcceptanceTest {
   @Test
   final void getOldestPendingEventAgeSeconds_withPendingEvents() throws Exception {
     TransactionManager transactionManager = txManager();
+    
+    Instant start = Instant.now();
+    java.util.concurrent.atomic.AtomicReference<Instant> currentTime = 
+        new java.util.concurrent.atomic.AtomicReference<>(start);
+    
     TransactionOutbox outbox =
         TransactionOutbox.builder()
             .transactionManager(transactionManager)
@@ -195,21 +200,22 @@ class TestH2 extends AbstractAcceptanceTest {
             .persistor(Persistor.forDialect(connectionDetails().dialect()))
             .attemptFrequency(Duration.ofMillis(500))
             .submitter(Submitter.withExecutor(r -> {})) // Don't submit - keep it pending
+            .clockProvider(() -> java.time.Clock.fixed(currentTime.get(), java.time.ZoneOffset.UTC))
             .initializeImmediately(false)
             .build();
 
     outbox.initialize();
     clearOutbox();
 
-    // Schedule an event but prevent it from being processed
+    // Schedule an event at time T
     transactionManager.inTransaction(
         () -> outbox.schedule(InterfaceProcessor.class).process(1, "bar"));
 
-    Thread.sleep(2000);
+    // Advance clock by 3 seconds
+    currentTime.set(start.plusSeconds(3));
 
     long age = outbox.getOldestPendingEventAgeSeconds();
-    assertTrue(age >= 2, "Age should be at least 2 seconds, but was: " + age);
-    assertTrue(age < 10, "Age should be less than 10 seconds, but was: " + age);
+    assertEquals(3L, age, "Age should be exactly 3 seconds");
 
     // Clean up by clearing the outbox
     clearOutbox();

--- a/transactionoutbox-acceptance/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestH2.java
+++ b/transactionoutbox-acceptance/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestH2.java
@@ -220,7 +220,7 @@ class TestH2 extends AbstractAcceptanceTest {
             .build();
     cleanupOutbox.flush();
 
-    long ageAfterProcessing = outbox.getOldestPendingEventAgeSeconds();
+    long ageAfterProcessing = cleanupOutbox.getOldestPendingEventAgeSeconds();
     assertEquals(0L, ageAfterProcessing, "No pending events after processing");
   }
 }

--- a/transactionoutbox-acceptance/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestH2.java
+++ b/transactionoutbox-acceptance/src/test/java/com/gruelbox/transactionoutbox/acceptance/TestH2.java
@@ -211,16 +211,17 @@ class TestH2 extends AbstractAcceptanceTest {
     assertTrue(age >= 2, "Age should be at least 2 seconds, but was: " + age);
     assertTrue(age < 10, "Age should be less than 10 seconds, but was: " + age);
 
-    // Clean up - flush to process the event with a real executor
+    // Clean up - create a new outbox with active submitter and flush pending events
     TransactionOutbox cleanupOutbox =
         TransactionOutbox.builder()
             .transactionManager(transactionManager)
             .instantiator(Instantiator.using(clazz -> (InterfaceProcessor) (foo, bar) -> {}))
             .persistor(Persistor.forDialect(connectionDetails().dialect()))
             .build();
+    
     cleanupOutbox.flush();
-
-    long ageAfterProcessing = cleanupOutbox.getOldestPendingEventAgeSeconds();
-    assertEquals(0L, ageAfterProcessing, "No pending events after processing");
+    
+    // Verify no pending events remain
+    assertEquals(0L, outbox.getOldestPendingEventAgeSeconds(), "No pending events after processing");
   }
 }

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultPersistor.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/DefaultPersistor.java
@@ -767,4 +767,24 @@ public class DefaultPersistor implements Persistor, Validatable {
       return rs.next() && (rs.getInt(1) == 1);
     }
   }
+
+  @Override
+  public Instant getOldestPendingEventTime(Transaction tx) throws SQLException {
+    String sql =
+        "SELECT MIN(nextAttemptTime) FROM "
+            + tableName
+            + " WHERE blocked = "
+            + dialect.booleanValue(false)
+            + " AND processed = "
+            + dialect.booleanValue(false);
+    //noinspection resource
+    try (Statement stmt = tx.connection().createStatement();
+        ResultSet rs = stmt.executeQuery(sql)) {
+      if (rs.next()) {
+        Timestamp timestamp = rs.getTimestamp(1);
+        return timestamp != null ? timestamp.toInstant() : null;
+      }
+      return null;
+    }
+  }
 }

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Persistor.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/Persistor.java
@@ -228,4 +228,17 @@ public interface Persistor {
    * @param tx The current {@link Transaction}.
    */
   void clear(Transaction tx) throws Exception;
+
+  /**
+   * Returns the nextAttemptTime of the oldest pending event. This is used for monitoring and
+   * alerting on stuck or delayed events.
+   *
+   * <p>An event is considered pending if it is not blocked and not processed. The oldest event is
+   * determined by the minimum {@code nextAttemptTime}.
+   *
+   * @param tx The current {@link Transaction}.
+   * @return The oldest nextAttemptTime, or null if no pending events exist.
+   * @throws Exception Any exception.
+   */
+  Instant getOldestPendingEventTime(Transaction tx) throws Exception;
 }

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/StubPersistor.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/StubPersistor.java
@@ -96,4 +96,9 @@ public class StubPersistor implements Persistor {
   public boolean checkConnection(Transaction tx) throws Exception {
     return true;
   }
+
+  @Override
+  public Instant getOldestPendingEventTime(Transaction tx) throws Exception {
+    return null;
+  }
 }

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutbox.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutbox.java
@@ -199,6 +199,34 @@ public interface TransactionOutbox {
 
   void processBatchNow(List<TransactionOutboxEntry> entries);
 
+  /**
+   * Returns the age in seconds of the oldest pending (unblocked, unprocessed) event. This is useful
+   * for monitoring and alerting on stuck or delayed events.
+   *
+   * <p>The age is calculated as the difference between the current time and the {@code
+   * nextAttemptTime} of the oldest pending event. Events are considered pending if they are not
+   * blocked and not processed.
+   *
+   * <p>This method starts a new transaction internally, so it can be safely called from any
+   * context, including scheduled monitoring tasks or health check endpoints.
+   *
+   * <p>Example usage for monitoring:
+   *
+   * <pre>{@code
+   * // Expose as a gauge metric for DataDog/Prometheus
+   * long ageSeconds = outbox.getOldestPendingEventAgeSeconds();
+   * metrics.gauge("outbox.oldest_pending_event.age", ageSeconds);
+   *
+   * // Alert if age exceeds threshold
+   * if (ageSeconds > 120) {
+   *   alerting.triggerIncident("Outbox events stuck for " + ageSeconds + " seconds");
+   * }
+   * }</pre>
+   *
+   * @return The age in seconds of the oldest pending event, or 0 if no pending events exist.
+   */
+  long getOldestPendingEventAgeSeconds();
+
   /** Builder for {@link TransactionOutbox}. */
   @ToString
   abstract class TransactionOutboxBuilder {

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxImpl.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxImpl.java
@@ -367,6 +367,30 @@ final class TransactionOutboxImpl implements TransactionOutbox, Validatable {
     }
   }
 
+  @Override
+  public long getOldestPendingEventAgeSeconds() {
+    if (!initialized.get()) {
+      throw new IllegalStateException("Not initialized");
+    }
+    try {
+      return transactionManager.inTransactionReturns(
+          tx -> {
+            try {
+              Instant oldestTime = persistor.getOldestPendingEventTime(tx);
+              if (oldestTime == null) {
+                return 0L;
+              }
+              Instant now = clockProvider.get().instant();
+              return now.getEpochSecond() - oldestTime.getEpochSecond();
+            } catch (Exception e) {
+              throw (RuntimeException) Utils.uncheckAndThrow(e);
+            }
+          });
+    } catch (Exception e) {
+      throw (RuntimeException) Utils.uncheckAndThrow(e);
+    }
+  }
+
   private <T> T schedule(
       Class<T> clazz, String uniqueRequestId, String topic, Duration delayForAtLeast) {
     if (!initialized.get()) {

--- a/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxImpl.java
+++ b/transactionoutbox-core/src/main/java/com/gruelbox/transactionoutbox/TransactionOutboxImpl.java
@@ -372,23 +372,19 @@ final class TransactionOutboxImpl implements TransactionOutbox, Validatable {
     if (!initialized.get()) {
       throw new IllegalStateException("Not initialized");
     }
-    try {
-      return transactionManager.inTransactionReturns(
-          tx -> {
-            try {
-              Instant oldestTime = persistor.getOldestPendingEventTime(tx);
-              if (oldestTime == null) {
-                return 0L;
-              }
-              Instant now = clockProvider.get().instant();
-              return now.getEpochSecond() - oldestTime.getEpochSecond();
-            } catch (Exception e) {
-              throw (RuntimeException) Utils.uncheckAndThrow(e);
+    return transactionManager.inTransactionReturns(
+        tx -> {
+          try {
+            Instant oldestTime = persistor.getOldestPendingEventTime(tx);
+            if (oldestTime == null) {
+              return 0L;
             }
-          });
-    } catch (Exception e) {
-      throw (RuntimeException) Utils.uncheckAndThrow(e);
-    }
+            Instant now = clockProvider.get().instant();
+            return now.getEpochSecond() - oldestTime.getEpochSecond();
+          } catch (Exception e) {
+            throw (RuntimeException) Utils.uncheckAndThrow(e);
+          }
+        });
   }
 
   private <T> T schedule(

--- a/transactionoutbox-testing/src/main/java/com/gruelbox/transactionoutbox/testing/AbstractPersistorTest.java
+++ b/transactionoutbox-testing/src/main/java/com/gruelbox/transactionoutbox/testing/AbstractPersistorTest.java
@@ -467,4 +467,77 @@ public abstract class AbstractPersistorTest {
       throw e;
     }
   }
+
+  @Test
+  public void testGetOldestPendingEventTime_noPendingEvents() throws Exception {
+    txManager()
+        .inTransactionThrows(tx -> assertThat(persistor().getOldestPendingEventTime(tx), nullValue()));
+  }
+
+  @Test
+  public void testGetOldestPendingEventTime_singlePendingEvent() throws Exception {
+    Instant timestamp = now.minusSeconds(60);
+    TransactionOutboxEntry entry = createEntry("FOO1", timestamp, false);
+    txManager().inTransactionThrows(tx -> persistor().save(tx, entry));
+    txManager()
+        .inTransactionThrows(
+            tx -> assertThat(persistor().getOldestPendingEventTime(tx), equalTo(timestamp)));
+  }
+
+  @Test
+  public void testGetOldestPendingEventTime_multiplePendingEvents() throws Exception {
+    Instant oldest = now.minusSeconds(120);
+    Instant newer = now.minusSeconds(60);
+    Instant newest = now.minusSeconds(30);
+    
+    txManager()
+        .inTransactionThrows(
+            tx -> {
+              persistor().save(tx, createEntry("FOO1", newer, false));
+              persistor().save(tx, createEntry("FOO2", oldest, false));
+              persistor().save(tx, createEntry("FOO3", newest, false));
+            });
+    
+    txManager()
+        .inTransactionThrows(
+            tx -> assertThat(persistor().getOldestPendingEventTime(tx), equalTo(oldest)));
+  }
+
+  @Test
+  public void testGetOldestPendingEventTime_excludesBlockedEvents() throws Exception {
+    Instant oldest = now.minusSeconds(120);
+    Instant newer = now.minusSeconds(60);
+    
+    txManager()
+        .inTransactionThrows(
+            tx -> {
+              persistor().save(tx, createEntry("FOO1", oldest, true));  // Blocked
+              persistor().save(tx, createEntry("FOO2", newer, false));  // Not blocked
+            });
+    
+    txManager()
+        .inTransactionThrows(
+            tx -> assertThat(persistor().getOldestPendingEventTime(tx), equalTo(newer)));
+  }
+
+  @Test
+  public void testGetOldestPendingEventTime_excludesProcessedEvents() throws Exception {
+    Instant oldest = now.minusSeconds(120);
+    Instant newer = now.minusSeconds(60);
+    
+    TransactionOutboxEntry processedEntry = createEntry("FOO1", oldest, false);
+    processedEntry.setProcessed(true);
+    TransactionOutboxEntry pendingEntry = createEntry("FOO2", newer, false);
+    
+    txManager()
+        .inTransactionThrows(
+            tx -> {
+              persistor().save(tx, processedEntry);
+              persistor().save(tx, pendingEntry);
+            });
+    
+    txManager()
+        .inTransactionThrows(
+            tx -> assertThat(persistor().getOldestPendingEventTime(tx), equalTo(newer)));
+  }
 }


### PR DESCRIPTION
## Summary

Add monitoring capabilities for the transaction outbox to enable production alerting on stuck/delayed events.

### Changes

- **Add `getOldestPendingEventAgeSeconds()` method**
  - Returns the age in seconds of the oldest pending event
  - Returns 0 if no pending events exist
  - Useful for monitoring and alerting (e.g., alert if age > 120 seconds)
  - Creates new transaction internally for safe querying from any context

- **Add `getOldestPendingEventTime()` to Persistor interface**
  - Database query: `SELECT MIN(nextAttemptTime) WHERE blocked=false AND processed=false`
  - Implemented in DefaultPersistor
  - Stub implementation returns null (no pending events)

- **Document retry count access in listener callbacks**
  - `entry.getAttempts()` already available in all listener methods
  - No code changes needed, just documentation

- **Comprehensive monitoring documentation**
  - Examples for accessing retry count in listeners
  - Examples for monitoring oldest pending event age
  - Spring Boot Actuator health check integration
  - Micrometer/DataDog/Prometheus metrics examples
  - Recommended alerting thresholds (60s warning, 120s critical)

- **Tests**
  - Unit tests for `getOldestPendingEventTime()` in AbstractPersistorTest
  - Integration tests for `getOldestPendingEventAgeSeconds()` in TestH2
  - Coverage for no events, single event, multiple events, blocked/processed filtering

## Test Plan

- [x] Core module tests pass
- [x] Acceptance tests pass (TestH2)
- [x] Testing module tests pass (AbstractPersistorTest)
- [x] All new tests pass
- [x] No linter errors

## Requested By

Payroll team for production incident alerting when events are stuck for more than 120 seconds.


Made with [Cursor](https://cursor.com)